### PR TITLE
Remove leading whitespace

### DIFF
--- a/HeaderTabs.php
+++ b/HeaderTabs.php
@@ -1,4 +1,3 @@
-
 <?php
 /**
  * Header Tabs extension


### PR DESCRIPTION
I didn't figure out how to do the Gerrit thing, so here goes.

This change removed some leading whitespace that was introduced by accident. The whitespace can lead to some quite catastrophic fails if it is used in conjunction with an extension that wants to write headers (ie. for redirecting to OpenID).