### PR TITLE
Stops edit button from going to 'Hauptseite'

### DIFF
--- a/skins/ext.headertabs.core.js
+++ b/skins/ext.headertabs.core.js
@@ -86,7 +86,7 @@
 		var $anchor = $( '#edittab' ).find( 'a' );
 		$anchor.attr(
 			'href',
-			mw.util.getUrl( 'Hauptseite', { action:'edit' } ) + section
+			mw.util.getUrl( null, { action:'edit' } ) + section
 		);
 	}
 


### PR DESCRIPTION
The edit tab button was going to a non-existent 'Hauptseite' page in the current code.